### PR TITLE
fix(test): use macOS compatible touch command

### DIFF
--- a/tests/setup.bats
+++ b/tests/setup.bats
@@ -98,7 +98,7 @@ teardown() {
   
   # Create OLD marker file (61 minutes ago)
   touch "$fake_dir/.last-update-check"
-  touch -d "61 minutes ago" "$fake_dir/.last-update-check"
+  env TZ=XXX0 touch -d "$(TZ=XXX+1:01 date +%FT%T)" "$fake_dir/.last-update-check"
   
   run "$SCRIPT_DIR/setup.sh" "https://example.com/repo" "$fake_dir"
   
@@ -156,7 +156,7 @@ teardown() {
   
   # Create old marker to trigger update check
   touch "$fake_dir/.last-update-check"
-  touch -d "61 minutes ago" "$fake_dir/.last-update-check"
+  env TZ=XXX0 touch -d "$(TZ=XXX+1:01 date +%FT%T)" "$fake_dir/.last-update-check"
   
   # Run setup in non-interactive mode (CI=true auto-updates)
   export CI=true


### PR DESCRIPTION
The `touch` command on macOS does not support relative times like `touch -d '61 minutes ago'`. Instead we can generate a specific timestamp using the `date` command and by manipulating the timezone. For instance, to generate a timestamp representing a point in time 61 minutes ago we can use a time zone offset of 1:01 relative to a time zone with zero offset and use the zero offset timezone when we touch the file.

This fixes the following tests on macOS:

 1. setup.sh checks for updates if marker file is older than 1 hour
 2. setup.sh update handles untracked files without failing

See: https://unix.stackexchange.com/questions/804394/how-to-portably-find-file-modified-less-than-10-minutes-ago/804400#804400

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
