### PR TITLE
fix(test): explicitly init git repo with main as default branch

### DIFF
--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -98,7 +98,7 @@ setup_isolated_home() {
 # Usage: init_git_repo
 init_git_repo() {
   export GIT_CONFIG_NOSYSTEM=1
-  git init -q
+  git init -q -b main
   git config user.email "test@example.com"
   git config user.name "Test User"
   # Make git objects writable so safe_temp_del can clean up


### PR DESCRIPTION
Some of our tests expect that the name of the default git branch is 'main'. Here we explicitly set the name of the default branch to 'main' instead of relying on the host machine to be correctly configured.

This avoids test failures on machines that are configured to use a different name for the default branch, e.g. 'master' or 'trunk'.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
