### PR TITLE
docs: propagate exit code from subshell in justfile examples

### DIFF
--- a/examples/java-justfile
+++ b/examples/java-justfile
@@ -199,6 +199,7 @@ test:
 [group('build')]
 build:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Building" "mvn install -DskipTests"
     mvn {{maven_opts}} install -DskipTests
@@ -208,6 +209,7 @@ build:
 [group('build')]
 clean:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Cleaning" "mvn clean"
     mvn clean

--- a/examples/node-justfile
+++ b/examples/node-justfile
@@ -180,6 +180,7 @@ lint-node-format-fix:
 [group('test')]
 test:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Running tests" "npm test"
     npm test
@@ -193,6 +194,7 @@ test:
 [group('build')]
 build:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Building" "npm run build"
     npm run build
@@ -202,6 +204,7 @@ build:
 [group('build')]
 clean:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Cleaning" "rm -rf dist node_modules"
     rm -rf dist node_modules


### PR DESCRIPTION
When we execute commands in a subshell errors are normally not propagated to the invoking shell. This means that the caller have no chance to react on the problems found in the subshell.

In order to propagate the exit status to just we need to set the `-e` flag. For good measure we include the whole 'strict mode' setting which also aborts execution on undeclared variable usage and pipe failures.

    set -euo pipefail

This ensures that the subshell execution is aborted as soon as a problem is encountered and that the exit code is properly propagated to the invoking shell. This in turn enables command chaining based on the outcome, i.e.:

    just test; and echo success; or echo failure

Without the fix, the command above would always print 'success' even when there are test failures. With the fix, it would print 'success' if, and only if, all tests pass and 'false' otherwise.

One way to take advantage of this is to conditionally chain commands together:

    just test; and git push

The command above will only push the local changes when all tests pass. Without the fix, the test step have no impact on the push, and you stand the risk of pushing changes with test failures.

See: http://redsymbol.net/articles/unofficial-bash-strict-mode/

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
