### PR TITLE
docs: propagate exit codes in examples

### DIFF
--- a/examples/base-justfile
+++ b/examples/base-justfile
@@ -72,6 +72,7 @@ tools-install: _ensure-devtools
 [group('verify')]
 verify: _ensure-devtools check-tools lint-all
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_success "All checks passed"
 
@@ -133,6 +134,7 @@ lint-xml:
 [group('lint-fix')]
 lint-fix: _ensure-devtools lint-yaml-fix lint-markdown-fix lint-shell-fmt-fix
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_success "All auto-fixes completed"
 

--- a/examples/java-justfile
+++ b/examples/java-justfile
@@ -159,6 +159,7 @@ lint-java-fmt:
 [group('lint-fix')]
 lint-fix: _ensure-devtools lint-yaml-fix lint-markdown-fix lint-shell-fmt-fix lint-java-fmt-fix
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_success "All auto-fixes completed"
 
@@ -199,6 +200,7 @@ test:
 [group('build')]
 build:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Building" "mvn install -DskipTests"
     mvn {{maven_opts}} install -DskipTests
@@ -208,6 +210,7 @@ build:
 [group('build')]
 clean:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Cleaning" "mvn clean"
     mvn clean

--- a/examples/node-justfile
+++ b/examples/node-justfile
@@ -72,6 +72,7 @@ deps-install:
 [group('verify')]
 verify: _ensure-devtools check-tools lint-all test
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_success "All checks passed"
 
@@ -83,6 +84,7 @@ verify: _ensure-devtools check-tools lint-all test
 [group('lint')]
 lint-all: _ensure-devtools lint-node
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just --justfile {{devtools_dir}}/justfile lint-base
     just_success "All linting checks completed"
@@ -152,6 +154,7 @@ lint-node-ts-types:
 [group('lint-fix')]
 lint-fix: _ensure-devtools lint-yaml-fix lint-markdown-fix lint-shell-fmt-fix lint-node-format-fix
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_success "All auto-fixes completed"
 
@@ -180,6 +183,7 @@ lint-node-format-fix:
 [group('test')]
 test:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Running tests" "npm test"
     npm test
@@ -193,6 +197,7 @@ test:
 [group('build')]
 build:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Building" "npm run build"
     npm run build
@@ -202,6 +207,7 @@ build:
 [group('build')]
 clean:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Cleaning" "rm -rf dist node_modules"
     rm -rf dist node_modules

--- a/tests/verify.bats
+++ b/tests/verify.bats
@@ -197,6 +197,78 @@ EOF
   refute_output --partial "1 skipped"
 }
 
+@test "verify.sh runs all linters even when early ones fail" {
+  cat > justfile << 'EOF'
+lint-version-control:
+    @printf "DEVBASE_CHECK_STATUS=fail\n"
+    @printf "DEVBASE_CHECK_DETAILS=dirty tree\n"
+lint-commits:
+    @printf "DEVBASE_CHECK_STATUS=fail\n"
+    @printf "DEVBASE_CHECK_DETAILS=bad format\n"
+lint-secrets:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-yaml:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-markdown:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-shell:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-shell-fmt:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-actions:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-license:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-container:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-xml:
+    @printf "DEVBASE_CHECK_STATUS=fail\n"
+    @printf "DEVBASE_CHECK_DETAILS=invalid xml\n"
+EOF
+
+  run "$SCRIPT_DIR/verify.sh"
+
+  assert_failure
+  # All three failures must appear — proves linters after early failures still ran
+  assert_output --partial "Working Tree"
+  assert_output --partial "Commits"
+  assert_output --partial "XML"
+  assert_output --partial "3 failed"
+}
+
+@test "verify.sh reports correct pass count alongside failures" {
+  cat > justfile << 'EOF'
+lint-version-control:
+    @printf "DEVBASE_CHECK_STATUS=fail\n"
+lint-commits:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-secrets:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-yaml:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-markdown:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-shell:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-shell-fmt:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-actions:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-license:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-container:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+lint-xml:
+    @printf "DEVBASE_CHECK_STATUS=pass\n"
+EOF
+
+  run "$SCRIPT_DIR/verify.sh"
+
+  assert_failure
+  assert_output --partial "1 failed"
+  assert_output --partial "10 passed"
+}
+
 @test "verify.sh fails when explicit fail marker is reported" {
   cat > justfile << 'EOF'
 lint-version-control:


### PR DESCRIPTION
# Pull Request Description

Add idiomatic "strict" bash to examples.
Add test so we still propagate

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
