### PR TITLE
fix: improve update

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ That's it.
 
 ### Updates
 
-Run `just setup-devtools` again to check for updates:
+Two update paths:
 
-- **Interactive**: Prompts "Update available: vX.Y.Z. Update? [y/N]"
-- **CI/non-interactive**: Auto-updates to latest tag
+- **Passive** — `just setup-devtools` checks for updates at most once an hour. Interactive terminals get a `[y/N]` prompt; CI/non-interactive shells auto-update to the latest tag. Offline/flaky-network runs stay silent and retry on the next invocation.
+- **On-demand** — `just update-devtools` force-updates right now, no TTL, no prompt. Pass `--ref <branch-or-tag>` to try an unreleased branch or roll back to a specific tag.
+
+Upgrading from an older version? See [`docs/MIGRATION-0.5.0.md`](docs/MIGRATION-0.5.0.md) for the unstick paths if your install is stale.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ That's it.
 
 Two update paths:
 
-- **Passive** — `just setup-devtools` checks for updates at most once an hour. Interactive terminals get a `[y/N]` prompt; CI/non-interactive shells auto-update to the latest tag. Offline/flaky-network runs stay silent and retry on the next invocation.
+- **Passive** — `just setup-devtools` checks for updates at most once an hour. Interactive terminals get a `[y/N]` prompt. Non-interactive shells (CI, pipes) leave the installed version alone — pin via Renovate and bump through PRs. Set `DEVBASE_CHECK_AUTO_UPDATE=1` to opt in to auto-update. Offline/flaky-network runs stay silent and retry on the next invocation.
 - **On-demand** — `just update-devtools` force-updates right now, no TTL, no prompt. Pass `--ref <branch-or-tag>` to try an unreleased branch or roll back to a specific tag.
 
 Upgrading from an older version? See [`docs/MIGRATION-0.5.0.md`](docs/MIGRATION-0.5.0.md) for the unstick paths if your install is stale.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -112,3 +112,48 @@ just test
 ## Available Commands
 
 Run `just` to see all available commands.
+
+## Migrating your justfile
+
+If your downstream repo has an older `setup-devtools` recipe that inlines
+clone + update logic, you can shrink it. The install/update logic now
+lives entirely in `scripts/setup.sh` — consumers only need to ensure the
+directory exists and delegate.
+
+Replace the old inline recipe:
+
+```text
+setup-devtools:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -d "{{devtools_dir}}" ]]; then
+        if ! git -C "{{devtools_dir}}" fetch --tags --depth 1 --quiet 2>/dev/null; then
+            printf "\033[0;33m! Could not check for updates...\033[0m\n"
+        elif [[ -f "{{devtools_dir}}/scripts/setup.sh" ]]; then
+            "{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
+        fi
+    else
+        # ... 10+ lines of clone + fetch + checkout logic ...
+    fi
+```
+
+with the new two-line shim:
+
+```text
+setup-devtools:
+    @[[ -d "{{devtools_dir}}" ]] || { mkdir -p "$(dirname "{{devtools_dir}}")" && git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"; }
+    @"{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
+```
+
+No other changes are required. `devtools_repo`, `devtools_dir`,
+`_ensure-devtools`, and every `lint-*` recipe stay as-is. Behaviour is
+equivalent: first run clones; `setup.sh` handles the initial tag
+checkout and subsequent hourly update checks.
+
+Optional environment variables (unset by default):
+
+- `DEVBASE_CHECK_SKIP_UPDATES=1` — never check for updates.
+- `DEVBASE_CHECK_AUTO_UPDATE=1` — auto-update without prompting.
+
+See `examples/base-justfile`, `examples/java-justfile`, and
+`examples/node-justfile` for the full template.

--- a/docs/MIGRATION-0.5.0.md
+++ b/docs/MIGRATION-0.5.0.md
@@ -1,0 +1,194 @@
+<!--
+SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Migration to devbase-check 0.5.0
+
+0.5.0 is a quality-of-life release aimed at two recurring pain points:
+
+1. **Users got silently stuck on old versions.** The `just lint-all` flow used to warn on any network hiccup and skip its own update check, so users behind VPNs or intermittent networks never received updates.
+2. **"Tool not found" errors were opaque.** When `mise install` silently skipped a pin (classic case: `pipx:reuse` when pipx isn't on the host), linters either fell through to a stray system binary or failed with a generic error. The real cause — "your mise install is incomplete" — was invisible.
+
+Both problems are now fixed. This guide tells you what changed, how to unstick if you're already stale, and how (optionally) to simplify your project's justfile.
+
+---
+
+## TL;DR — one action you probably want to take
+
+Add an `update-devtools` recipe to your project's justfile (see [Consumer justfile updates](#consumer-justfile-updates-optional-but-recommended) below). From then on, `just update-devtools` force-updates to the latest release tag on demand, no prompts, no TTL.
+
+If you've been on an old version and `just lint-all` has silently stopped picking up updates, see [For stuck users — how to unstick](#for-stuck-users--how-to-unstick).
+
+---
+
+## For stuck users — how to unstick
+
+If you've been seeing (or silently missing) `Could not check for updates (no network connection)` warnings, or your devbase-check install hasn't moved in months, you're likely caught in the old recipe's pre-fetch trap. Pick one:
+
+**Option 1 — manual pull** (preserves the existing checkout):
+
+```bash
+dir="${XDG_DATA_HOME:-$HOME/.local/share}/devbase-check"
+git -C "$dir" fetch --tags
+latest=$(git -C "$dir" describe --tags --abbrev=0 origin/main)
+git -C "$dir" checkout "$latest"
+```
+
+**Option 2 — use the escape-hatch recipe** (works even if your consumer justfile hasn't been updated):
+
+```bash
+just -f "${XDG_DATA_HOME:-$HOME/.local/share}/devbase-check/justfile" update
+```
+
+This bypasses your own project's justfile entirely and uses devbase-check's internal `update` recipe, which resolves paths via `justfile_directory()` and works from any cwd.
+
+**Option 3 — nuke and re-clone**:
+
+```bash
+rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/devbase-check"
+just setup-devtools
+```
+
+Any of the three gets you onto 0.5.0. After that, the new `setup.sh` is self-healing: it stays silent on transient network failures and retries on the next run instead of warning + giving up.
+
+---
+
+## What's new
+
+### `just update-devtools` — explicit, on-demand update
+
+Previously, updates happened passively: `setup.sh` checked once an hour during `just setup-devtools` invocations, and either prompted or auto-updated. There was no way to say "update now regardless of the TTL" without touching the marker file by hand.
+
+```bash
+just update-devtools              # latest release tag, bypass TTL
+just update-devtools --ref feat/my-change   # try an unreleased branch
+just update-devtools --ref v0.4.2           # roll back to a specific tag
+just update-devtools --help
+```
+
+Under the hood this runs `scripts/update.sh`, which:
+
+- Fetches unconditionally (not gated by the marker).
+- Stashes untracked/uncommitted state first so local experimentation isn't lost.
+- For `--ref`, uses `git checkout --detach FETCH_HEAD` — works uniformly for branches, tags, and SHAs.
+- Refreshes `.last-update-check` on success so setup.sh doesn't immediately re-check.
+
+### Silent offline, retriable next run
+
+`setup.sh` no longer warns on fetch failure, and — importantly — does not touch the hour-TTL marker when the fetch fails. Net effect: on a flaky network, the next `just lint-all` actually tries again instead of waiting out the hour. Users with sporadic connectivity now get updates on their next good-network moment instead of never.
+
+### First-run self-healing
+
+If the consumer's `setup-devtools` recipe did a bare clone but the tag-checkout didn't complete (e.g., network cut between `git clone` and `git checkout <tag>`), the next run now notices HEAD isn't on a tag and silently completes the install. No prompt, no error — it just works on the next invocation.
+
+### Mise install is incomplete — one clear message, not a cascade
+
+If any pin in `.mise.toml` is reported missing by `mise ls --missing`, `just lint-all` now fails fast with one message:
+
+```text
+✗ mise install is incomplete — run: mise install
+  - pipx:reuse
+  (to skip: --ignore-missing-linters or DEVBASE_CHECK_IGNORE_MISSING_LINTERS=1)
+```
+
+Each linter still has its own guard, but when running a specific linter (e.g. `./linters/license.sh`) it fires only when **that linter's own tool** is the one missing. Running `./linters/license.sh` when `aqua:mvdan/sh` is missing no longer errors — `reuse` is fine, the linter just runs.
+
+### `--ignore-missing-linters` and related opt-outs
+
+```bash
+just lint-all --ignore-missing-linters     # proceed; affected linters skip
+```
+
+Affected linters emit a `skip` marker, so the summary table shows them as `-` with a `mise pin missing` detail rather than wrongly reporting pass/fail.
+
+Three env-var opt-outs cover the other shapes:
+
+| Variable | Effect |
+|---|---|
+| `DEVBASE_CHECK_IGNORE_MISSING_LINTERS=1` | Same as `--ignore-missing-linters`. |
+| `DEVBASE_CHECK_ALLOW_SYSTEM_TOOLS=1` | Skip the mise-pin check entirely; fall through to whatever's on PATH. For locked-down environments where `mise install` can't complete. |
+| `DEVBASE_CHECK_SKIP_UPDATES=1` | Never run the passive update check. For CI pipelines pinned by SHA, air-gapped environments. |
+| `DEVBASE_CHECK_AUTO_UPDATE=1` | Auto-accept updates without the `[y/N]` prompt. For humans who want auto-update in a terminal. |
+
+---
+
+## Consumer justfile updates (optional but recommended)
+
+The example justfiles (`examples/{base,java,node}-justfile`) have been simplified. Applying the same changes to your own justfile is optional but gives you the benefit of the new flow without fighting it.
+
+### Shrink `setup-devtools`
+
+**Before** (~22 lines of inline shell that duplicated `setup.sh`):
+
+```just
+setup-devtools:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -d "{{devtools_dir}}" ]]; then
+        if ! git -C "{{devtools_dir}}" fetch --tags --depth 1 --quiet 2>/dev/null; then
+            printf "\033[0;33m! Could not check for updates (no network connection)\033[0m\n"
+        elif [[ -f "{{devtools_dir}}/scripts/setup.sh" ]]; then
+            "{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
+        fi
+    else
+        printf "Cloning devbase-check to %s...\n" "{{devtools_dir}}"
+        mkdir -p "$(dirname "{{devtools_dir}}")"
+        git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"
+        # ... more inline clone/checkout ...
+    fi
+```
+
+**After** (two lines, delegates everything):
+
+```just
+setup-devtools:
+    @[[ -d "{{devtools_dir}}" ]] || { mkdir -p "$(dirname "{{devtools_dir}}")" && git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"; }
+    @"{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
+```
+
+Why this is better: no consumer-side pre-fetch. The consumer's recipe doesn't warn or short-circuit on network failure. All logic lives in one place (`setup.sh`), which improves idempotently as we release new versions.
+
+### Add `update-devtools`
+
+```just
+update-devtools *ARGS:
+    @"{{devtools_dir}}/scripts/update.sh" "{{devtools_dir}}" {{ ARGS }}
+```
+
+Now `just update-devtools` is at your fingertips.
+
+The first time the new `setup.sh` runs in your install, it prints a one-time tip pointing at these example files, then stays quiet thereafter (marker file `.tip-minimal-recipe-shown`).
+
+---
+
+## Behavioural changes to be aware of
+
+- **`setup.sh` is silent on fetch failure.** You will no longer see `Could not check for updates (no network connection)`. If you had log-scraping on that string, update it. The marker is also no longer touched when the fetch fails, so next-run behaviour changes from "wait an hour" to "retry immediately."
+
+- **Per-linter guard is now tool-specific.** Calling `./linters/<x>.sh` directly only errors on a missing mise pin if **its** tool is the one affected. Node linters (`eslint`, `prettier`, `tsc`) no longer call the guard at all — they don't have mise pins (they use `npx`).
+
+- **`check-tools.sh` output labels tool provenance.** Each listed tool now shows `(mise)` or `(system)` — useful for spotting a stray system copy when you thought you were running the pinned version.
+
+- **Dependency changes.** `gommitlint` bumped to `0.9.10`. `rumdl` switched from the `ubi` backend to `aqua` and is pinned at `v0.1.62` (newer aqua versions fail attestation verification — upstream registry issue, tracked separately).
+
+- **No breaking API changes.** Existing `just verify`, `just lint-all`, individual `just lint-*` recipes, and the script invocations continue to work. If you haven't updated your consumer justfile, everything keeps functioning — you just miss the benefits of the new flow until you migrate.
+
+---
+
+## Where things are
+
+| Change | Files |
+|---|---|
+| Update flow | `scripts/setup.sh`, `scripts/update.sh` (new), `justfile` (new `update` recipe) |
+| Mise-install guard | `utils/mise-tool.sh`, all `linters/*.sh` |
+| Preflight + CLI | `scripts/verify.sh`, `justfile` |
+| Consumer examples | `examples/{base,java,node}-justfile` |
+| Tests | `tests/setup.bats`, `tests/update.bats`, `tests/verify.bats`, `tests/utils-mise-tool.bats` |
+
+If you hit anything not covered here, the escape hatch is always:
+
+```bash
+just -f "${XDG_DATA_HOME:-$HOME/.local/share}/devbase-check/justfile" update
+```

--- a/docs/MIGRATION-0.5.0.md
+++ b/docs/MIGRATION-0.5.0.md
@@ -4,9 +4,7 @@ SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
 SPDX-License-Identifier: CC0-1.0
 -->
 
-
-
-## For stuck users — how to unstick
+# For stuck users — how to unstick
 
 If you've been seeing (or silently missing) `Could not check for updates (no network connection)` warnings, or your devbase-check install hasn't moved in months, you're likely caught in the old recipe's pre-fetch trap. Pick one:
 
@@ -51,8 +49,6 @@ just update-devtools --ref v0.4.2           # roll back to a specific tag
 just update-devtools --help
 ```
 
-
-
 ## Consumer justfile updates (optional but recommended)
 
 The example justfiles (`examples/{base,java,node}-justfile`) have been simplified.
@@ -96,10 +92,7 @@ update-devtools *ARGS:
     @"{{devtools_dir}}/scripts/update.sh" "{{devtools_dir}}" {{ ARGS }}
 ```
 
-
 ---
-
-
 
 If you hit anything not covered here, the escape hatch is always:
 

--- a/docs/MIGRATION-0.5.0.md
+++ b/docs/MIGRATION-0.5.0.md
@@ -4,24 +4,7 @@ SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
 SPDX-License-Identifier: CC0-1.0
 -->
 
-# Migration to devbase-check 0.5.0
 
-0.5.0 is a quality-of-life release aimed at two recurring pain points:
-
-1. **Users got silently stuck on old versions.** The `just lint-all` flow used to warn on any network hiccup and skip its own update check, so users behind VPNs or intermittent networks never received updates.
-2. **"Tool not found" errors were opaque.** When `mise install` silently skipped a pin (classic case: `pipx:reuse` when pipx isn't on the host), linters either fell through to a stray system binary or failed with a generic error. The real cause — "your mise install is incomplete" — was invisible.
-
-Both problems are now fixed. This guide tells you what changed, how to unstick if you're already stale, and how (optionally) to simplify your project's justfile.
-
----
-
-## TL;DR — one action you probably want to take
-
-Add an `update-devtools` recipe to your project's justfile (see [Consumer justfile updates](#consumer-justfile-updates-optional-but-recommended) below). From then on, `just update-devtools` force-updates to the latest release tag on demand, no prompts, no TTL.
-
-If you've been on an old version and `just lint-all` has silently stopped picking up updates, see [For stuck users — how to unstick](#for-stuck-users--how-to-unstick).
-
----
 
 ## For stuck users — how to unstick
 
@@ -59,7 +42,7 @@ Any of the three gets you onto 0.5.0. After that, the new `setup.sh` is self-hea
 
 ### `just update-devtools` — explicit, on-demand update
 
-Previously, updates happened passively: `setup.sh` checked once an hour during `just setup-devtools` invocations, and either prompted or auto-updated. There was no way to say "update now regardless of the TTL" without touching the marker file by hand.
+Previously, updates happened passively: `setup.sh` checked once an hour during `just setup-devtools` invocations, and either prompted or auto-updated.
 
 ```bash
 just update-devtools              # latest release tag, bypass TTL
@@ -68,55 +51,11 @@ just update-devtools --ref v0.4.2           # roll back to a specific tag
 just update-devtools --help
 ```
 
-Under the hood this runs `scripts/update.sh`, which:
 
-- Fetches unconditionally (not gated by the marker).
-- Stashes untracked/uncommitted state first so local experimentation isn't lost.
-- For `--ref`, uses `git checkout --detach FETCH_HEAD` — works uniformly for branches, tags, and SHAs.
-- Refreshes `.last-update-check` on success so setup.sh doesn't immediately re-check.
-
-### Silent offline, retriable next run
-
-`setup.sh` no longer warns on fetch failure, and — importantly — does not touch the hour-TTL marker when the fetch fails. Net effect: on a flaky network, the next `just lint-all` actually tries again instead of waiting out the hour. Users with sporadic connectivity now get updates on their next good-network moment instead of never.
-
-### First-run self-healing
-
-If the consumer's `setup-devtools` recipe did a bare clone but the tag-checkout didn't complete (e.g., network cut between `git clone` and `git checkout <tag>`), the next run now notices HEAD isn't on a tag and silently completes the install. No prompt, no error — it just works on the next invocation.
-
-### Mise install is incomplete — one clear message, not a cascade
-
-If any pin in `.mise.toml` is reported missing by `mise ls --missing`, `just lint-all` now fails fast with one message:
-
-```text
-✗ mise install is incomplete — run: mise install
-  - pipx:reuse
-  (to skip: --ignore-missing-linters or DEVBASE_CHECK_IGNORE_MISSING_LINTERS=1)
-```
-
-Each linter still has its own guard, but when running a specific linter (e.g. `./linters/license.sh`) it fires only when **that linter's own tool** is the one missing. Running `./linters/license.sh` when `aqua:mvdan/sh` is missing no longer errors — `reuse` is fine, the linter just runs.
-
-### `--ignore-missing-linters` and related opt-outs
-
-```bash
-just lint-all --ignore-missing-linters     # proceed; affected linters skip
-```
-
-Affected linters emit a `skip` marker, so the summary table shows them as `-` with a `mise pin missing` detail rather than wrongly reporting pass/fail.
-
-Three env-var opt-outs cover the other shapes:
-
-| Variable | Effect |
-|---|---|
-| `DEVBASE_CHECK_IGNORE_MISSING_LINTERS=1` | Same as `--ignore-missing-linters`. |
-| `DEVBASE_CHECK_ALLOW_SYSTEM_TOOLS=1` | Skip the mise-pin check entirely; fall through to whatever's on PATH. For locked-down environments where `mise install` can't complete. |
-| `DEVBASE_CHECK_SKIP_UPDATES=1` | Never run the passive update check. For CI pipelines pinned by SHA, air-gapped environments. |
-| `DEVBASE_CHECK_AUTO_UPDATE=1` | Auto-accept updates without the `[y/N]` prompt. For humans who want auto-update in a terminal. |
-
----
 
 ## Consumer justfile updates (optional but recommended)
 
-The example justfiles (`examples/{base,java,node}-justfile`) have been simplified. Applying the same changes to your own justfile is optional but gives you the benefit of the new flow without fighting it.
+The example justfiles (`examples/{base,java,node}-justfile`) have been simplified.
 
 ### Shrink `setup-devtools`
 
@@ -157,35 +96,10 @@ update-devtools *ARGS:
     @"{{devtools_dir}}/scripts/update.sh" "{{devtools_dir}}" {{ ARGS }}
 ```
 
-Now `just update-devtools` is at your fingertips.
-
-The first time the new `setup.sh` runs in your install, it prints a one-time tip pointing at these example files, then stays quiet thereafter (marker file `.tip-minimal-recipe-shown`).
 
 ---
 
-## Behavioural changes to be aware of
 
-- **`setup.sh` is silent on fetch failure.** You will no longer see `Could not check for updates (no network connection)`. If you had log-scraping on that string, update it. The marker is also no longer touched when the fetch fails, so next-run behaviour changes from "wait an hour" to "retry immediately."
-
-- **Per-linter guard is now tool-specific.** Calling `./linters/<x>.sh` directly only errors on a missing mise pin if **its** tool is the one affected. Node linters (`eslint`, `prettier`, `tsc`) no longer call the guard at all — they don't have mise pins (they use `npx`).
-
-- **`check-tools.sh` output labels tool provenance.** Each listed tool now shows `(mise)` or `(system)` — useful for spotting a stray system copy when you thought you were running the pinned version.
-
-- **Dependency changes.** `gommitlint` bumped to `0.9.10`. `rumdl` switched from the `ubi` backend to `aqua` and is pinned at `v0.1.62` (newer aqua versions fail attestation verification — upstream registry issue, tracked separately).
-
-- **No breaking API changes.** Existing `just verify`, `just lint-all`, individual `just lint-*` recipes, and the script invocations continue to work. If you haven't updated your consumer justfile, everything keeps functioning — you just miss the benefits of the new flow until you migrate.
-
----
-
-## Where things are
-
-| Change | Files |
-|---|---|
-| Update flow | `scripts/setup.sh`, `scripts/update.sh` (new), `justfile` (new `update` recipe) |
-| Mise-install guard | `utils/mise-tool.sh`, all `linters/*.sh` |
-| Preflight + CLI | `scripts/verify.sh`, `justfile` |
-| Consumer examples | `examples/{base,java,node}-justfile` |
-| Tests | `tests/setup.bats`, `tests/update.bats`, `tests/verify.bats`, `tests/utils-mise-tool.bats` |
 
 If you hit anything not covered here, the escape hatch is always:
 

--- a/examples/base-justfile
+++ b/examples/base-justfile
@@ -29,30 +29,16 @@ default:
 # SETUP
 # ==================================================================================== #
 
-# ▪ Setup devtools (clone or update)
+# ▪ Setup devtools (clone on first run, then delegate to devbase-check)
 [group('setup')]
 setup-devtools:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [[ -d "{{devtools_dir}}" ]]; then
-        # Try to check for updates, warn if no network connection
-        if ! git -C "{{devtools_dir}}" fetch --tags --depth 1 --quiet 2>/dev/null; then
-            printf "\033[0;33m! Could not check for updates (no network connection)\033[0m\n"
-        elif [[ -f "{{devtools_dir}}/scripts/setup.sh" ]]; then
-            "{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
-        fi
-    else
-        printf "Cloning devbase-check to %s...\n" "{{devtools_dir}}"
-        mkdir -p "$(dirname "{{devtools_dir}}")"
-        git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"
-        git -C "{{devtools_dir}}" fetch --tags --depth 1 --quiet
-        latest=$(git -C "{{devtools_dir}}" describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
-        if [[ -n "$latest" ]]; then
-            git -C "{{devtools_dir}}" fetch --depth 1 origin tag "$latest" --quiet
-            git -C "{{devtools_dir}}" checkout "$latest" --quiet
-        fi
-        printf "Installed devbase-check %s\n" "${latest:-main}"
-    fi
+    @[[ -d "{{devtools_dir}}" ]] || { mkdir -p "$(dirname "{{devtools_dir}}")" && git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"; }
+    @"{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
+
+# ▪ Force-update devtools to latest release tag (or --ref <branch/tag/sha>)
+[group('setup')]
+update-devtools *ARGS:
+    @"{{devtools_dir}}/scripts/update.sh" "{{devtools_dir}}" {{ ARGS }}
 
 # Check required tools
 [group('setup')]

--- a/examples/java-justfile
+++ b/examples/java-justfile
@@ -31,30 +31,16 @@ default:
 # SETUP
 # ==================================================================================== #
 
-# ▪ Setup devtools (clone or update)
+# ▪ Setup devtools (clone on first run, then delegate to devbase-check)
 [group('setup')]
 setup-devtools:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [[ -d "{{devtools_dir}}" ]]; then
-        # Try to check for updates, warn if no network connection
-        if ! git -C "{{devtools_dir}}" fetch --tags --depth 1 --quiet 2>/dev/null; then
-            printf "\033[0;33m! Could not check for updates (no network connection)\033[0m\n"
-        elif [[ -f "{{devtools_dir}}/scripts/setup.sh" ]]; then
-            "{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
-        fi
-    else
-        printf "Cloning devbase-check to %s...\n" "{{devtools_dir}}"
-        mkdir -p "$(dirname "{{devtools_dir}}")"
-        git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"
-        git -C "{{devtools_dir}}" fetch --tags --depth 1 --quiet
-        latest=$(git -C "{{devtools_dir}}" describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
-        if [[ -n "$latest" ]]; then
-            git -C "{{devtools_dir}}" fetch --depth 1 origin tag "$latest" --quiet
-            git -C "{{devtools_dir}}" checkout "$latest" --quiet
-        fi
-        printf "Installed devbase-check %s\n" "${latest:-main}"
-    fi
+    @[[ -d "{{devtools_dir}}" ]] || { mkdir -p "$(dirname "{{devtools_dir}}")" && git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"; }
+    @"{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
+
+# ▪ Force-update devtools to latest release tag (or --ref <branch/tag/sha>)
+[group('setup')]
+update-devtools *ARGS:
+    @"{{devtools_dir}}/scripts/update.sh" "{{devtools_dir}}" {{ ARGS }}
 
 # Check required tools
 [group('setup')]

--- a/examples/node-justfile
+++ b/examples/node-justfile
@@ -29,30 +29,16 @@ default:
 # SETUP
 # ==================================================================================== #
 
-# ▪ Setup devtools (clone or update)
+# ▪ Setup devtools (clone on first run, then delegate to devbase-check)
 [group('setup')]
 setup-devtools:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [[ -d "{{devtools_dir}}" ]]; then
-        # Try to check for updates, warn if no network connection
-        if ! git -C "{{devtools_dir}}" fetch --tags --depth 1 --quiet 2>/dev/null; then
-            printf "\033[0;33m! Could not check for updates (no network connection)\033[0m\n"
-        elif [[ -f "{{devtools_dir}}/scripts/setup.sh" ]]; then
-            "{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
-        fi
-    else
-        printf "Cloning devbase-check to %s...\n" "{{devtools_dir}}"
-        mkdir -p "$(dirname "{{devtools_dir}}")"
-        git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"
-        git -C "{{devtools_dir}}" fetch --tags --depth 1 --quiet
-        latest=$(git -C "{{devtools_dir}}" describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
-        if [[ -n "$latest" ]]; then
-            git -C "{{devtools_dir}}" fetch --depth 1 origin tag "$latest" --quiet
-            git -C "{{devtools_dir}}" checkout "$latest" --quiet"
-        fi
-        printf "Installed devbase-check %s\n" "${latest:-main}"
-    fi
+    @[[ -d "{{devtools_dir}}" ]] || { mkdir -p "$(dirname "{{devtools_dir}}")" && git clone --depth 1 "{{devtools_repo}}" "{{devtools_dir}}"; }
+    @"{{devtools_dir}}/scripts/setup.sh" "{{devtools_repo}}" "{{devtools_dir}}"
+
+# ▪ Force-update devtools to latest release tag (or --ref <branch/tag/sha>)
+[group('setup')]
+update-devtools *ARGS:
+    @"{{devtools_dir}}/scripts/update.sh" "{{devtools_dir}}" {{ ARGS }}
 
 # Check required tools
 [group('setup')]

--- a/justfile
+++ b/justfile
@@ -36,6 +36,15 @@ default:
 install:
     @mise install
 
+# ▪ Force-update this devbase-check install to latest tag (or --ref <ref>)
+#
+# Escape hatch for consumers whose own justfile doesn't (yet) have an
+# `update-devtools` recipe. Invoke from anywhere:
+#   just -f ~/.local/share/devbase-check/justfile update [--ref <ref>]
+[group('setup')]
+update *ARGS:
+    @"{{justfile_directory()}}/scripts/update.sh" "{{justfile_directory()}}" {{ ARGS }}
+
 # ==================================================================================== #
 # VERIFY - Quality assurance
 # ==================================================================================== #

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -68,14 +68,19 @@ check_for_updates() {
 
   [[ "$current" == "$latest" || "$latest" == "unknown" ]] && return 0
 
-  # Auto-update in CI, non-interactive shells, or when explicitly opted in.
-  if [[ "${CI:-false}" == "true" ]] ||
-    [[ "${DEVBASE_CHECK_AUTO_UPDATE:-0}" == "1" ]] ||
-    [[ ! -t 0 ]]; then
+  # Explicit opt-in: auto-update regardless of shell type.
+  if [[ "${DEVBASE_CHECK_AUTO_UPDATE:-0}" == "1" ]]; then
     print_info "Auto-updating devtools to $latest"
     update_to_version "$latest"
     return 0
   fi
+
+  # Non-interactive (CI, pipes, background jobs): do NOT auto-update.
+  # Version management in CI is the caller's responsibility — pin the
+  # devbase-check version via Renovate or equivalent. Use
+  # DEVBASE_CHECK_AUTO_UPDATE=1 to opt in if you really want
+  # track-latest-tag behaviour.
+  [[ ! -t 0 ]] && return 0
 
   # Interactive: ask once per check. A "no" means "not now" — the hour TTL
   # will let the next run ask again until the user accepts or a newer tag

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -54,40 +54,64 @@ check_for_updates() {
   local current="$1"
   local latest="$2"
 
-  if [[ "$current" != "$latest" && "$latest" != "unknown" ]]; then
-    # Auto-update in CI/non-interactive mode, prompt in interactive mode
-    if [[ "${CI:-false}" == "true" ]] || [[ ! -t 0 ]]; then
-      print_info "Auto-updating devtools to $latest"
-      update_to_version "$latest"
-    else
-      print_info "devtools installed: $current"
-      read -p "Update available: $latest. Update? [y/N] " -n 1 -r
-      printf "\n"
-      if [[ $REPLY =~ ^[Yy]$ ]]; then
-        update_to_version "$latest"
-      fi
-    fi
+  [[ "$current" == "$latest" || "$latest" == "unknown" ]] && return 0
+
+  # Auto-update in CI, non-interactive shells, or when explicitly opted in.
+  if [[ "${CI:-false}" == "true" ]] \
+    || [[ "${DEVBASE_CHECK_AUTO_UPDATE:-0}" == "1" ]] \
+    || [[ ! -t 0 ]]; then
+    print_info "Auto-updating devtools to $latest"
+    update_to_version "$latest"
+    return 0
   fi
+
+  # Interactive: ask once per check. A "no" means "not now" — the hour TTL
+  # will let the next run ask again until the user accepts or a newer tag
+  # ships.
+  print_info "devtools installed: $current"
+  read -p "Update available: $latest. Update? [y/N] " -n 1 -r
+  printf "\n"
+  [[ $REPLY =~ ^[Yy]$ ]] && update_to_version "$latest"
 }
 
 main() {
-  if [[ -d "$DIR" ]]; then
-    # Skip update check if checked within the last hour (use marker file mtime)
-    local marker="$DIR/.last-update-check"
-    if [[ -f "$marker" ]] && [[ -z "$(find "$marker" -mmin +60 2>/dev/null)" ]]; then
-      return 0
-    fi
+  # Opt-out: never check for updates.
+  [[ "${DEVBASE_CHECK_SKIP_UPDATES:-0}" == "1" ]] && return 0
 
-    # Try to fetch tags only (shallow), but don't fail if network is unavailable
-    if ! git -C "$DIR" fetch --tags --depth 1 --quiet 2>/dev/null; then
-      print_warning "Could not check for updates (no network connection)"
-      return 0
-    fi
-    touch "$marker"
-    check_for_updates "$(get_current_version)" "$(get_latest_version)"
-  else
+  if [[ ! -d "$DIR" ]]; then
     clone_repo
+    return 0
   fi
+
+  local marker="$DIR/.last-update-check"
+
+  # First run after a bare clone (consumer bootstrap did `git clone` but
+  # didn't pick a tag): no marker present and HEAD isn't a tag. Silently
+  # check out the latest tag to complete the install — don't prompt the
+  # user about upgrading something they just installed.
+  if [[ ! -f "$marker" ]] \
+    && ! git -C "$DIR" describe --exact-match --tags HEAD >/dev/null 2>&1; then
+    # Full-depth fetch so `git describe` can resolve a tag reachable from
+    # origin/main even when the branch tip is past the latest release.
+    git -C "$DIR" fetch --tags --quiet 2>/dev/null || return 0
+    local latest
+    latest=$(get_latest_version)
+    [[ -n "$latest" && "$latest" != "unknown" ]] && update_to_version "$latest"
+    touch "$marker"
+    return 0
+  fi
+
+  # Hour TTL between checks, keyed off the marker's mtime.
+  if [[ -f "$marker" ]] && [[ -z "$(find "$marker" -mmin +60 2>/dev/null)" ]]; then
+    return 0
+  fi
+
+  # Silent on network failure: don't touch the marker so the next run
+  # retries instead of waiting out the TTL.
+  git -C "$DIR" fetch --tags --depth 1 --quiet 2>/dev/null || return 0
+
+  touch "$marker"
+  check_for_updates "$(get_current_version)" "$(get_latest_version)"
 }
 
 main

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -33,17 +33,6 @@ update_to_version() {
   git -C "$DIR" stash --include-untracked --quiet 2>/dev/null || true
   git -C "$DIR" checkout "$version" --quiet
   print_success "Updated to $version"
-  maybe_nudge_recipe_migration
-}
-
-# One-time nudge for users whose project justfile still has the old
-# ~22-line setup-devtools recipe. Harmless if they've already migrated —
-# the tip prints once per install dir, then is silenced by a marker.
-maybe_nudge_recipe_migration() {
-  local flag="$DIR/.tip-minimal-recipe-shown"
-  [[ -f "$flag" ]] && return 0
-  print_info "Tip: a shorter setup-devtools recipe is available — see ${DIR}/examples/base-justfile"
-  touch "$flag"
 }
 
 clone_repo() {
@@ -59,7 +48,6 @@ clone_repo() {
     git -C "$DIR" checkout "$latest" --quiet
   fi
   print_success "Installed devtools ${latest:-main}"
-  maybe_nudge_recipe_migration
 }
 
 check_for_updates() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -33,6 +33,17 @@ update_to_version() {
   git -C "$DIR" stash --include-untracked --quiet 2>/dev/null || true
   git -C "$DIR" checkout "$version" --quiet
   print_success "Updated to $version"
+  maybe_nudge_recipe_migration
+}
+
+# One-time nudge for users whose project justfile still has the old
+# ~22-line setup-devtools recipe. Harmless if they've already migrated —
+# the tip prints once per install dir, then is silenced by a marker.
+maybe_nudge_recipe_migration() {
+  local flag="$DIR/.tip-minimal-recipe-shown"
+  [[ -f "$flag" ]] && return 0
+  print_info "Tip: a shorter setup-devtools recipe is available — see ${DIR}/examples/base-justfile"
+  touch "$flag"
 }
 
 clone_repo() {
@@ -48,6 +59,7 @@ clone_repo() {
     git -C "$DIR" checkout "$latest" --quiet
   fi
   print_success "Installed devtools ${latest:-main}"
+  maybe_nudge_recipe_migration
 }
 
 check_for_updates() {
@@ -57,9 +69,9 @@ check_for_updates() {
   [[ "$current" == "$latest" || "$latest" == "unknown" ]] && return 0
 
   # Auto-update in CI, non-interactive shells, or when explicitly opted in.
-  if [[ "${CI:-false}" == "true" ]] \
-    || [[ "${DEVBASE_CHECK_AUTO_UPDATE:-0}" == "1" ]] \
-    || [[ ! -t 0 ]]; then
+  if [[ "${CI:-false}" == "true" ]] ||
+    [[ "${DEVBASE_CHECK_AUTO_UPDATE:-0}" == "1" ]] ||
+    [[ ! -t 0 ]]; then
     print_info "Auto-updating devtools to $latest"
     update_to_version "$latest"
     return 0
@@ -89,8 +101,8 @@ main() {
   # didn't pick a tag): no marker present and HEAD isn't a tag. Silently
   # check out the latest tag to complete the install — don't prompt the
   # user about upgrading something they just installed.
-  if [[ ! -f "$marker" ]] \
-    && ! git -C "$DIR" describe --exact-match --tags HEAD >/dev/null 2>&1; then
+  if [[ ! -f "$marker" ]] &&
+    ! git -C "$DIR" describe --exact-match --tags HEAD >/dev/null 2>&1; then
     # Full-depth fetch so `git describe` can resolve a tag reachable from
     # origin/main even when the branch tip is past the latest release.
     git -C "$DIR" fetch --tags --quiet 2>/dev/null || return 0

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: MIT
+
+# Force-update an existing devbase-check install. Unlike setup.sh's
+# passive hour-TTL check, this is explicit: always fetches, always
+# checks out the target ref, no prompts.
+#
+#   update.sh <install-dir>              — latest release tag
+#   update.sh <install-dir> --ref <ref>  — specific branch/tag/sha
+#
+# Fetches are performed against the install's configured `origin`, so
+# mirror-cloned installs stay on their mirror.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../utils/colors.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: update.sh <install-dir> [--ref <ref>]
+
+Force-updates an existing devbase-check install, bypassing setup.sh's
+hour TTL and update-check marker. Fetches from the install's `origin`.
+For first-time installs, use `just setup-devtools` instead.
+
+Arguments:
+  <install-dir>  Path to the existing devbase-check checkout.
+
+Options:
+  --ref <ref>    Check out <ref> (branch, tag, or sha) instead of the
+                 latest release tag on origin/main. Useful for trying an
+                 unreleased branch, e.g. --ref feat/my-change.
+  -h, --help     Show this help.
+EOF
+}
+
+DIR=""
+REF=""
+
+while (($# > 0)); do
+  case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --ref)
+    [[ $# -ge 2 ]] || {
+      print_error "--ref requires an argument"
+      exit 2
+    }
+    REF="$2"
+    shift 2
+    ;;
+  --ref=*)
+    REF="${1#--ref=}"
+    shift
+    ;;
+  --)
+    shift
+    break
+    ;;
+  -*)
+    print_error "unknown option: $1"
+    usage >&2
+    exit 2
+    ;;
+  *)
+    if [[ -z "$DIR" ]]; then
+      DIR="$1"
+    else
+      print_error "unexpected argument: $1"
+      usage >&2
+      exit 2
+    fi
+    shift
+    ;;
+  esac
+done
+
+if [[ -z "$DIR" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -d "$DIR/.git" ]]; then
+  print_error "$DIR is not a git checkout — run 'just setup-devtools' first"
+  exit 1
+fi
+
+# Record where we are before moving — shown in the success line so the
+# user knows what actually changed.
+before=$(git -C "$DIR" describe --tags --exact-match HEAD 2>/dev/null ||
+  git -C "$DIR" rev-parse --short HEAD 2>/dev/null ||
+  echo "unknown")
+
+# Preserve user's uncommitted/untracked state before the checkout. Only
+# stash if there's actually something to stash, so we can truthfully
+# tell the user afterwards. The if-chain keeps a stash failure from
+# aborting the script under set -e.
+stashed=0
+if [[ -n "$(git -C "$DIR" status --porcelain 2>/dev/null)" ]] &&
+  git -C "$DIR" stash --include-untracked --quiet 2>/dev/null; then
+  stashed=1
+fi
+
+if [[ -n "$REF" ]]; then
+  print_info "Fetching $REF from origin..."
+  git -C "$DIR" fetch --depth 1 origin "$REF" --quiet
+  # Detach to whatever was fetched — works uniformly for branch, tag, or sha.
+  git -C "$DIR" checkout --detach FETCH_HEAD --quiet
+  target="$REF"
+else
+  print_info "Fetching latest release tag..."
+  git -C "$DIR" fetch --tags --depth 1 --quiet
+  target=$(git -C "$DIR" describe --tags --abbrev=0 origin/main 2>/dev/null || true)
+  if [[ -z "$target" ]]; then
+    print_error "no release tag found on origin/main"
+    exit 1
+  fi
+  git -C "$DIR" fetch --depth 1 origin tag "$target" --quiet 2>/dev/null || true
+  git -C "$DIR" checkout "$target" --quiet
+fi
+
+# Refresh the passive update-check marker so setup.sh doesn't immediately
+# re-check on the next `just verify`.
+touch "$DIR/.last-update-check"
+
+print_success "devbase-check updated to $target (from $before)"
+if ((stashed)); then
+  print_info "Local changes were stashed — run 'git -C $DIR stash list' to inspect"
+fi

--- a/tests/setup.bats
+++ b/tests/setup.bats
@@ -207,10 +207,11 @@ teardown() {
   touch "$fake_dir/.last-update-check"
   env TZ=XXX0 touch -d "$(TZ=XXX+1:01 date +%FT%T)" "$fake_dir/.last-update-check"
   
-  # Run setup in non-interactive mode (CI=true auto-updates)
-  export CI=true
+  # Non-interactive no longer auto-updates by default (CI/Renovate owns
+  # version bumps). Use the explicit opt-in.
+  export DEVBASE_CHECK_AUTO_UPDATE=1
   run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir"
-  
+
   assert_success
   assert_output --partial "Updated to v1.0.1"
 
@@ -218,6 +219,41 @@ teardown() {
   cd "$fake_dir"
   run git describe --tags --abbrev=0
   assert_output "v1.0.1"
+}
+
+@test "setup.sh does NOT auto-update on non-tty (CI/pipe) without opt-in" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+
+  mkdir -p "$fake_dir"
+  cd "$fake_dir"
+  export GIT_EDITOR=true
+  init_isolated_git_repo
+  git tag -a v1.0.0 -m "v1.0.0"
+  echo "new" >file.txt
+  git add file.txt
+  git commit -q -m "Update"
+  git tag -a v1.0.1 -m "v1.0.1"
+
+  git init -q --bare "$remote_dir"
+  git remote add origin "$remote_dir"
+  git push --all origin 2>/dev/null
+  git push --tags origin 2>/dev/null
+
+  git checkout v1.0.0 --quiet
+  touch "$fake_dir/.last-update-check"
+  env TZ=XXX0 touch -d "$(TZ=XXX+1:01 date +%FT%T)" "$fake_dir/.last-update-check"
+
+  # CI env set, but no DEVBASE_CHECK_AUTO_UPDATE — must NOT update.
+  export CI=true
+  run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir"
+
+  assert_success
+  refute_output --partial "Updated to v1.0.1"
+
+  cd "$fake_dir"
+  run git describe --tags --abbrev=0
+  assert_output "v1.0.0"
 }
 
 @test "setup.sh prints the recipe-migration tip once, then stays silent" {

--- a/tests/setup.bats
+++ b/tests/setup.bats
@@ -245,8 +245,11 @@ teardown() {
   env TZ=XXX0 touch -d "$(TZ=XXX+1:01 date +%FT%T)" "$fake_dir/.last-update-check"
 
   # CI env set, but no DEVBASE_CHECK_AUTO_UPDATE — must NOT update.
+  # Redirect stdin from /dev/null so [[ -t 0 ]] is false even when bats
+  # is invoked from an interactive terminal; otherwise setup.sh falls
+  # through to the `read -p` prompt and the test hangs.
   export CI=true
-  run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir"
+  run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir" </dev/null
 
   assert_success
   refute_output --partial "Updated to v1.0.1"
@@ -256,39 +259,3 @@ teardown() {
   assert_output "v1.0.0"
 }
 
-@test "setup.sh prints the recipe-migration tip once, then stays silent" {
-  local fake_dir="${TEST_DIR}/devtools"
-  local remote_dir="${TEST_DIR}/remote.git"
-
-  # Bare remote: one tagged commit plus an untagged commit on top, so
-  # a fresh bare clone's HEAD is past the latest tag — same state the
-  # new consumer bootstrap leaves things in.
-  git init -q --bare "$remote_dir"
-  local work="${TEST_DIR}/work"
-  mkdir -p "$work" && cd "$work"
-  export GIT_EDITOR=true
-  init_isolated_git_repo
-  git tag -a v1.0.0 -m "v1.0.0"
-  echo "post" >file2.txt
-  git add file2.txt
-  git commit -q -m "post-release"
-  git remote add origin "$remote_dir"
-  git push --all origin 2>/dev/null
-  git push --tags origin 2>/dev/null
-
-  git clone --quiet "$remote_dir" "$fake_dir"
-
-  # First run completes the install; tip should appear.
-  run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir"
-  assert_success
-  assert_output --partial "shorter setup-devtools recipe"
-  assert_file_exists "$fake_dir/.tip-minimal-recipe-shown"
-
-  # Age the update-check marker so the next run doesn't short-circuit.
-  env TZ=XXX0 touch -d "$(TZ=XXX+1:01 date +%FT%T)" "$fake_dir/.last-update-check"
-
-  # Second run — tip should not re-appear because the flag is set.
-  run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir"
-  assert_success
-  refute_output --partial "shorter setup-devtools recipe"
-}

--- a/tests/setup.bats
+++ b/tests/setup.bats
@@ -213,9 +213,46 @@ teardown() {
   
   assert_success
   assert_output --partial "Updated to v1.0.1"
-  
+
   # Verify we're now on v1.0.1
   cd "$fake_dir"
   run git describe --tags --abbrev=0
   assert_output "v1.0.1"
+}
+
+@test "setup.sh prints the recipe-migration tip once, then stays silent" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+
+  # Bare remote: one tagged commit plus an untagged commit on top, so
+  # a fresh bare clone's HEAD is past the latest tag — same state the
+  # new consumer bootstrap leaves things in.
+  git init -q --bare "$remote_dir"
+  local work="${TEST_DIR}/work"
+  mkdir -p "$work" && cd "$work"
+  export GIT_EDITOR=true
+  init_isolated_git_repo
+  git tag -a v1.0.0 -m "v1.0.0"
+  echo "post" >file2.txt
+  git add file2.txt
+  git commit -q -m "post-release"
+  git remote add origin "$remote_dir"
+  git push --all origin 2>/dev/null
+  git push --tags origin 2>/dev/null
+
+  git clone --quiet "$remote_dir" "$fake_dir"
+
+  # First run completes the install; tip should appear.
+  run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir"
+  assert_success
+  assert_output --partial "shorter setup-devtools recipe"
+  assert_file_exists "$fake_dir/.tip-minimal-recipe-shown"
+
+  # Age the update-check marker so the next run doesn't short-circuit.
+  env TZ=XXX0 touch -d "$(TZ=XXX+1:01 date +%FT%T)" "$fake_dir/.last-update-check"
+
+  # Second run — tip should not re-appear because the flag is set.
+  run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir"
+  assert_success
+  refute_output --partial "shorter setup-devtools recipe"
 }

--- a/tests/setup.bats
+++ b/tests/setup.bats
@@ -94,6 +94,83 @@ teardown() {
 # Update with untracked files tests
 # =============================================================================
 
+@test "setup.sh checks out latest tag on first run after bare clone" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+
+  # Bare remote where the branch tip is an UNtagged commit — simulating
+  # the common case where main has moved past the latest release tag.
+  git init -q --bare "$remote_dir"
+  local work="${TEST_DIR}/work"
+  mkdir -p "$work"
+  cd "$work"
+  export GIT_EDITOR=true
+  init_isolated_git_repo
+  git tag -a v1.0.0 -m "v1.0.0"
+  echo "updated" >file.txt
+  git add file.txt
+  git commit -q -m "Update"
+  git tag -a v1.0.1 -m "v1.0.1"
+  echo "post-release work" >file2.txt
+  git add file2.txt
+  git commit -q -m "Work after release"
+  git remote add origin "$remote_dir"
+  git push --all origin 2>/dev/null
+  git push --tags origin 2>/dev/null
+
+  # Simulate what the consumer shim does: plain clone, HEAD ends up on
+  # the untagged branch tip.
+  git clone --quiet "$remote_dir" "$fake_dir"
+  cd "$fake_dir"
+
+  # Precondition: fresh clone is on the branch tip (not a tag) and has no marker.
+  run git describe --exact-match --tags HEAD
+  assert_failure
+  assert_not_exist "$fake_dir/.last-update-check"
+
+  run "$SCRIPT_DIR/setup.sh" "$remote_dir" "$fake_dir"
+  assert_success
+  assert_file_exists "$fake_dir/.last-update-check"
+
+  # HEAD should now be on v1.0.1.
+  cd "$fake_dir"
+  run git describe --tags --abbrev=0
+  assert_output "v1.0.1"
+}
+
+@test "setup.sh is silent and leaves marker untouched when fetch fails" {
+  local fake_dir="${TEST_DIR}/devtools"
+  mkdir -p "$fake_dir"
+  cd "$fake_dir"
+  init_isolated_git_repo
+
+  # Stub git to succeed on the calls setup.sh needs before fetch
+  # (rev-parse etc.) but fail on fetch — simulating offline.
+  stub_repeated git '[[ "$1" == "fetch"* ]] || [[ "$*" == *"fetch"* ]] && exit 1
+                     exit 0'
+
+  run "$SCRIPT_DIR/setup.sh" "https://example.com/repo" "$fake_dir"
+
+  assert_success
+  refute_output --partial "Could not check for updates"
+  refute_output --partial "no network"
+  assert_not_exist "$fake_dir/.last-update-check"
+}
+
+@test "DEVBASE_CHECK_SKIP_UPDATES=1 disables the update check entirely" {
+  local fake_dir="${TEST_DIR}/devtools"
+  mkdir -p "$fake_dir"
+
+  # Stub git to fail so we'd see an error if setup.sh tried to fetch.
+  stub_repeated git 'echo "git should not be called"; exit 1'
+
+  DEVBASE_CHECK_SKIP_UPDATES=1 run "$SCRIPT_DIR/setup.sh" "https://example.com/repo" "$fake_dir"
+
+  assert_success
+  refute_output --partial "git should not be called"
+  assert_not_exist "$fake_dir/.last-update-check"
+}
+
 @test "setup.sh update handles untracked files without failing" {
   local fake_dir="${TEST_DIR}/devtools"
   local remote_dir="${TEST_DIR}/remote.git"

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -1,0 +1,233 @@
+#!/usr/bin/env bats
+
+# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: MIT
+
+bats_require_minimum_version 1.13.0
+
+load "${BATS_TEST_DIRNAME}/libs/bats-support/load.bash"
+load "${BATS_TEST_DIRNAME}/libs/bats-assert/load.bash"
+load "${BATS_TEST_DIRNAME}/libs/bats-file/load.bash"
+load "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+  common_setup
+  export SCRIPT_DIR="${DEVTOOLS_ROOT}/scripts"
+  export GIT_EDITOR=true
+}
+
+teardown() {
+  common_teardown
+}
+
+# Build a bare remote with two tagged releases and one post-release commit,
+# plus a feature branch 'feat/demo'. Clones into $fake_dir on branch main
+# pointing at v1.0.1 (latest tag).
+_fixture_remote() {
+  local remote_dir="$1" fake_dir="$2"
+
+  git init -q --bare "$remote_dir"
+  local work="${TEST_DIR}/work"
+  mkdir -p "$work"
+  (
+    cd "$work"
+    init_isolated_git_repo
+    git tag -a v1.0.0 -m "v1.0.0"
+    echo "one" >file.txt
+    git add file.txt
+    git commit -q -m "one"
+    git tag -a v1.0.1 -m "v1.0.1"
+
+    # Branch point for the --ref test.
+    git checkout -q -b feat/demo
+    echo "feature" >feat.txt
+    git add feat.txt
+    git commit -q -m "feature commit"
+
+    git checkout -q main 2>/dev/null || git checkout -q master 2>/dev/null
+    git remote add origin "$remote_dir"
+    git push --all origin 2>/dev/null
+    git push --tags origin 2>/dev/null
+  )
+  git clone --quiet "$remote_dir" "$fake_dir"
+  # Put the install on an outdated tag so "update" has something to do.
+  git -C "$fake_dir" checkout -q v1.0.0
+}
+
+# =============================================================================
+# Arg parsing
+# =============================================================================
+
+@test "update.sh requires an install-dir argument" {
+  run "$SCRIPT_DIR/update.sh"
+  assert_failure
+  assert_output --partial "Usage:"
+}
+
+@test "update.sh rejects unknown flags" {
+  run "$SCRIPT_DIR/update.sh" --bogus dir
+  assert_failure
+  assert_equal "$status" 2
+  assert_output --partial "unknown option"
+}
+
+@test "update.sh --help exits 0 with usage" {
+  run "$SCRIPT_DIR/update.sh" --help
+  assert_success
+  assert_output --partial "Usage:"
+  assert_output --partial "--ref"
+}
+
+@test "update.sh errors cleanly when install dir is not a git checkout" {
+  run "$SCRIPT_DIR/update.sh" "${TEST_DIR}/does-not-exist"
+  assert_failure
+  assert_output --partial "is not a git checkout"
+  assert_output --partial "just setup-devtools"
+}
+
+# =============================================================================
+# Default: update to latest tag
+# =============================================================================
+
+@test "update.sh: default (no --ref) checks out the latest tag on origin/main" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+  _fixture_remote "$remote_dir" "$fake_dir"
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir"
+  assert_success
+  assert_output --partial "updated to v1.0.1"
+
+  run git -C "$fake_dir" describe --tags --exact-match HEAD
+  assert_success
+  assert_output "v1.0.1"
+}
+
+@test "update.sh refreshes the passive update-check marker" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+  _fixture_remote "$remote_dir" "$fake_dir"
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir"
+  assert_success
+  assert_file_exists "$fake_dir/.last-update-check"
+}
+
+@test "update.sh: default fails cleanly when origin/main has no tags" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+
+  git init -q --bare "$remote_dir"
+  local work="${TEST_DIR}/work"
+  mkdir -p "$work"
+  (
+    cd "$work"
+    init_isolated_git_repo
+    git remote add origin "$remote_dir"
+    git push --all origin 2>/dev/null
+  )
+  git clone --quiet "$remote_dir" "$fake_dir"
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir"
+  assert_failure
+  assert_output --partial "no release tag found"
+}
+
+# =============================================================================
+# --ref: specific branch / tag
+# =============================================================================
+
+@test "update.sh --ref <branch>: checks out the branch tip (detached)" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+  _fixture_remote "$remote_dir" "$fake_dir"
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir" --ref feat/demo
+  assert_success
+  assert_output --partial "updated to feat/demo"
+
+  # HEAD should be on the feature branch's commit (has feat.txt).
+  assert_file_exists "$fake_dir/feat.txt"
+}
+
+@test "update.sh --ref <tag>: checks out that specific tag" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+  _fixture_remote "$remote_dir" "$fake_dir"
+
+  # Move install ahead first so we can verify --ref v1.0.0 moves it back.
+  git -C "$fake_dir" checkout -q v1.0.1
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir" --ref v1.0.0
+  assert_success
+  assert_output --partial "updated to v1.0.0"
+
+  run git -C "$fake_dir" describe --tags --exact-match HEAD
+  assert_success
+  assert_output "v1.0.0"
+}
+
+@test "update.sh --ref accepts --ref=<value> equals form" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+  _fixture_remote "$remote_dir" "$fake_dir"
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir" --ref=feat/demo
+  assert_success
+  assert_output --partial "updated to feat/demo"
+}
+
+@test "update.sh --ref without a value errors out" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+  _fixture_remote "$remote_dir" "$fake_dir"
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir" --ref
+  assert_failure
+  assert_equal "$status" 2
+  assert_output --partial "--ref requires an argument"
+}
+
+# =============================================================================
+# Local-state preservation
+# =============================================================================
+
+@test "update.sh stashes untracked files, completes the update, and tells the user where their work went" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+  _fixture_remote "$remote_dir" "$fake_dir"
+
+  # Untracked local experimentation that would otherwise conflict.
+  echo "my local notes" >"$fake_dir/untracked.txt"
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir"
+  assert_success
+  assert_output --partial "updated to v1.0.1"
+  assert_output --partial "(from v1.0.0)"
+  assert_output --partial "Local changes were stashed"
+}
+
+@test "devbase-check's own justfile exposes an 'update' escape-hatch recipe" {
+  # Users stuck on an old consumer justfile fall back to:
+  #   just -f $XDG_DATA_HOME/devbase-check/justfile update
+  # This smoke test confirms the recipe exists and delegates to update.sh,
+  # independent of the caller's cwd. (A full end-to-end invocation would
+  # require a fixture clone; the recipe body check is a cheap guard that
+  # catches the common breakage: a rename or relative-path regression.)
+  local devbase_justfile="${DEVTOOLS_ROOT}/justfile"
+  run just --justfile "$devbase_justfile" --show update
+  assert_success
+  assert_output --partial "scripts/update.sh"
+  assert_output --partial "justfile_directory()"
+}
+
+@test "update.sh stays quiet about stashing when the tree is already clean" {
+  local fake_dir="${TEST_DIR}/devtools"
+  local remote_dir="${TEST_DIR}/remote.git"
+  _fixture_remote "$remote_dir" "$fake_dir"
+
+  run "$SCRIPT_DIR/update.sh" "$fake_dir"
+  assert_success
+  refute_output --partial "Local changes were stashed"
+}


### PR DESCRIPTION
# Pull Request Description

Users on flaky networks could be stuck on whatever devbase-check version they first installed — the old flow warned on every failed fetch and then skipped the update check, never updating. This fixes that, plus makes CI stop silently floating to the latest tag on every release.

Changes
setup.sh is silent on fetch failure and keeps the TTL marker untouched, so the next run retries instead of waiting the hour out.
non-tty shells (incl. $CI=true) no longer auto-update. CI is expected to pin the devbase-check version via Renovate. Set DEVBASE_CHECK_AUTO_UPDATE=1 to keep the old
behaviour.
New just update-devtools for explicit on-demand updates. --ref <branch|tag|sha> pulls from an unreleased branch.
Consumer setup-devtools recipe shrinks from ~22 lines of inline bash to a 2-line bootstrap; all update logic lives in setup.sh.
Universal escape hatch for consumers on older justfiles: just -f ~/.local/share/devbase-check/justfile update.
Upgrading from an older version
See docs/MIGRATION-0.5.0.md for the three unstick paths. Short version for anyone silently stranded:

rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/devbase-check" && just setup-devtools

Depends on

Stacked on fix/mise-source-of-truth. That branch's 6 commits are also present here; merge it first and this reduces to 4 commits.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [ ] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
