### PR TITLE
style(yaml): preserve newlines in folded block scalars

### DIFF
--- a/linters/config/.yamlfmt
+++ b/linters/config/.yamlfmt
@@ -18,3 +18,4 @@ exclude:
 formatter:
   type: basic
   retain_line_breaks_single: true
+  scan_folded_as_literal: true


### PR DESCRIPTION
From the official documentation of yamlfmt:

> Option that will preserve newlines in folded block scalars (blocks
> that start with >).

Without this option newlines in folded block scalars are always replaced with spaces. This defeats the purpose of using a folded block scalar.

Consider this YAML:

	example_of_folded_block_scalar: >
	  Lorem ipsum dolor sit amet,
	  consectetur adipiscing elit,
	  sed do eiusmod tempor incididunt
	  ut labore et dolore magna aliqua.

The above is an example of a folded block scalar (as denoted by the `>` syntax). It is a way to break a long string into multiple lines for better readability. The newlines are interpreted as spaces.

However, without `scan_folded_as_literal: true` the linter would replace the newlines with spaces and place the whole text on a single line:

	example_of_folded_block_scalar: >
	  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

This is counterproductive. If I wanted to put the whole thing on a single line, I would use a regular string and not a folded block scalar.

See: https://yaml.cc/tutorial/yaml-multiline-string.html
See: https://github.com/google/yamlfmt/blob/main/docs/config-file.md

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
